### PR TITLE
v0.2 feature: support resuming from checkpoint 

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,10 @@
+{
+  "editor.tabSize": 2,
+  "editor.wordWrap": "wordWrapColumn",
+  "editor.wordWrapColumn": 100,
+  "files.trimTrailingWhitespace": true,
+  "files.insertFinalNewline": true,
+  "[markdown]": {
+    "files.trimTrailingWhitespace": false
+  }
+}

--- a/README.md
+++ b/README.md
@@ -10,8 +10,15 @@ npm install -g @gyugyu/webfonts-generator
 
 ## Usage
 
+Put YAML to `path/to/fonts-dir/fontspec.yaml` .
+
+```yaml
+name: myicons
+dest: ../dest
+```
+
 ```bash
-generate-webfonts path/to/fonts/*.svg --font-name myicons --dest dest
+generate-webfonts path/to/fonts-dir
 ```
 
 For more information, see `generate-webfonts --help` .

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   "dependencies": {
     "commander": "^6.1.0",
     "glob": "^7.1.6",
+    "js-yaml": "^3.14.0",
     "mkdirp": "^1.0.4",
     "svg2ttf": "^5.0.0",
     "svgicons2svgfont": "^9.1.1",
@@ -43,6 +44,7 @@
   "devDependencies": {
     "@types/commander": "^2.12.2",
     "@types/glob": "^7.1.3",
+    "@types/js-yaml": "^3.12.5",
     "@types/mkdirp": "^1.0.1",
     "@types/svg2ttf": "^5.0.0",
     "@types/ttf2woff2": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "generate-webfonts": "bin/generate-webfonts.js"
   },
   "scripts": {
+    "exec": "ts-node src/command.ts",
     "build": "npm run clean && npm run compile",
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gyugyu/webfonts-generator",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Webfonts generator CLI",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/CheckPoint.ts
+++ b/src/CheckPoint.ts
@@ -1,0 +1,28 @@
+import fs from 'fs'
+import path from 'path'
+
+const filename = 'fontspec.lock'
+
+export type FileRefs = Record<string, { codePoint: number, name: string }>
+
+interface CheckPoint {
+  version: string
+  fileRefs: FileRefs
+}
+
+export function loadCheckPoint(root: string): CheckPoint | null {
+  const file = path.join(root, filename)
+  if (fs.existsSync(file)) {
+    const content = fs.readFileSync(path.join(root, filename), 'utf8')
+    return JSON.parse(content)
+  }
+  return null
+}
+
+const { version } = require('../package.json')
+
+export function saveCheckPoint(root: string, checkPoint: Omit<CheckPoint, 'version'>): void {
+  const fullCheckPoint: CheckPoint = { ...checkPoint, version }
+  const content = JSON.stringify(fullCheckPoint, null, 2)
+  fs.writeFileSync(path.join(root, filename), content, 'utf8')
+}

--- a/src/FontSpec.ts
+++ b/src/FontSpec.ts
@@ -1,0 +1,23 @@
+import fs from 'fs'
+import yaml from 'js-yaml'
+import path from 'path'
+
+const filename = 'fontspec.yaml'
+
+interface FontSpec {
+  name: string
+  dest: string
+}
+
+function isFontSpec(o: any): o is FontSpec {
+  return typeof o === 'object' && typeof o.name === 'string' && typeof o.dest === 'string'
+}
+
+export function loadFontSpec(root: string): FontSpec {
+  const content = fs.readFileSync(path.join(root, filename), 'utf8')
+  const data = yaml.safeLoad(content)
+  if (isFontSpec(data)) {
+    return data
+  }
+  throw new Error()
+}

--- a/src/buildFontSetGenerator.ts
+++ b/src/buildFontSetGenerator.ts
@@ -1,8 +1,12 @@
-import FontGenerator, { GeneratedFont } from './generator/FontGenerator'
+import FontGenerator, { GeneratedFont, GeneratorOptions } from './generator/FontGenerator'
 import FromTTFGenerator, { GeneratorType as FromTTFGeneratorType } from './generator/FromTTFGenerator'
 import SVGGenerator from './generator/SVGGenerator'
 import TTFGenerator from './generator/TTFGenerator'
-import { Options, CodePoints } from './index'
+import { FileRefs } from './CheckPoint'
+
+export interface Options extends GeneratorOptions {
+  startCodePoint: number
+}
 
 class FontSetGenerator {
   generators: FontGenerator[]
@@ -23,10 +27,10 @@ class FontSetGenerator {
   }
 }
 
-export default function buildFontSetGenerator(options: Options, codePoints: CodePoints) {
+export default function buildFontSetGenerator(options: Options, fileRefs: FileRefs) {
   const generator = new FontSetGenerator()
 
-  const svgGenerator = new SVGGenerator(options, codePoints)
+  const svgGenerator = new SVGGenerator(options, fileRefs)
   if (options.types.includes('svg')) {
     generator.generators.push(svgGenerator)
   }

--- a/src/command.ts
+++ b/src/command.ts
@@ -1,26 +1,17 @@
 import { program } from 'commander'
 import fs from 'fs'
-import glob from 'glob'
-import path from 'path'
 import index from './index'
 
-program
-  .version('0.1.0')
-  .arguments('<dirOrGlob>')
-  .requiredOption('-n --font-name <fontName>', '(Required) Name for iconfont')
-  .requiredOption('-d, --dest <dest>', '(Required) Destination directory')
-  .action(async (dirOrGlob: string) => {
-    if (fs.existsSync(dirOrGlob)) {
-      const stat = fs.statSync(dirOrGlob)
-      if (stat.isDirectory()) {
-        dirOrGlob = path.join(dirOrGlob, '*')
-      }
-    }
-    const files = glob.sync(dirOrGlob)
+const pkgJson = require('../package.json')
 
-    const dest: string = program.dest
-    const fontName: string = program.fontName
-    await index(files, dest, { fontName })
+program
+  .version(pkgJson.version)
+  .arguments('<root>')
+  .action(async (root: string) => {
+    if (!fs.existsSync(root)) {
+      throw new Error()
+    }
+    await index(root)
   })
 
 program.parse(process.argv)

--- a/src/generator/FontGenerator.ts
+++ b/src/generator/FontGenerator.ts
@@ -1,5 +1,4 @@
 import { GeneratorType as FromTTFGeneratorType } from './FromTTFGenerator'
-import { Options } from '../index'
 
 export type GeneratorType = 'svg' | 'ttf' | FromTTFGeneratorType
 

--- a/src/generator/SVGGenerator.ts
+++ b/src/generator/SVGGenerator.ts
@@ -1,7 +1,7 @@
 import fs from 'fs'
 import SVGIcons2SVGFontStream from 'svgicons2svgfont'
 import FontGenerator, { GeneratorOptions } from './FontGenerator'
-import { CodePoints } from '../index'
+import { FileRefs } from '../CheckPoint'
 
 type SVGIconStream = fs.ReadStream & {
   metadata: {
@@ -11,12 +11,12 @@ type SVGIconStream = fs.ReadStream & {
 }
 
 export default class SVGGenerator extends FontGenerator {
-  codePoints: CodePoints
+  fileRefs: FileRefs
   font?: Buffer
 
-  constructor(options: GeneratorOptions, codePoints: CodePoints) {
+  constructor(options: GeneratorOptions, fileRefs: FileRefs) {
     super(options)
-    this.codePoints = codePoints
+    this.fileRefs = fileRefs
   }
 
   async init() { }
@@ -41,9 +41,9 @@ export default class SVGGenerator extends FontGenerator {
           resolve({ type: 'svg', data: buffer })
         })
 
-      Object.keys(this.codePoints).forEach(file => {
+      Object.keys(this.fileRefs).forEach(file => {
         const glyph: SVGIconStream = fs.createReadStream(file) as SVGIconStream
-        const { name, codePoint } = this.codePoints[file]
+        const { name, codePoint } = this.fileRefs[file]
 
         const ligature = name.split('').map((_, i) => {
           return String.fromCharCode(name.charCodeAt(i))

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,7 @@ const defaultOptions: Omit<Options, 'fontName'> = {
 
 function generateFileRefs(files: string[], codePoint: number, fileRefs: FileRefs = {}): FileRefs {
   codePoint = Object.values(fileRefs)
-    .reduce((pre, { codePoint: cur }) => cur > pre ? cur : pre, codePoint)
+    .reduce((pre, { codePoint: cur }) => cur >= pre ? cur + 1 : pre, codePoint)
 
   return files.reduce<FileRefs>((pre, file) => {
     const name = path.basename(file, path.extname(file))

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,55 +1,63 @@
-import buildFontSetGenerator from './buildFontSetGenerator'
 import fs from 'fs'
+import glob from 'glob'
 import mkdirp from 'mkdirp'
 import path from 'path'
-import { GeneratorOptions } from './generator/FontGenerator'
+import buildFontSetGenerator, { Options } from './buildFontSetGenerator'
+import { loadCheckPoint, saveCheckPoint, FileRefs } from './CheckPoint'
+import { loadFontSpec } from './FontSpec'
 
-export interface Options extends GeneratorOptions {
-  startCodePoint: number
-}
-
-const defaultOptions: Options = {
-  fontName: 'iconfont',
+const defaultOptions: Omit<Options, 'fontName'> = {
   types: ['eot', 'woff', 'woff2'],
   startCodePoint: 0xF101,
 }
 
-export type CodePoints = Record<string, { codePoint: number, name: string }>
+function generateFileRefs(files: string[], codePoint: number, fileRefs: FileRefs = {}): FileRefs {
+  codePoint = Object.values(fileRefs)
+    .reduce((pre, { codePoint: cur }) => cur > pre ? cur : pre, codePoint)
 
-function generateCodePoints(files: string[], codePoint: number): CodePoints {
-  return files.reduce<CodePoints>((pre, file) => {
+  return files.reduce<FileRefs>((pre, file) => {
     const name = path.basename(file, path.extname(file))
+    const ref = fileRefs[file]
+    if (ref) {
+      return { ...pre, [file]: ref }
+    }
     const cur = { [file]: { name, codePoint } }
     codePoint++
     return { ...pre, ...cur }
   }, {})
 }
 
-function buildManifest(options: Options, codePoints: CodePoints) {
+function buildManifest(options: Options, fileRefs: FileRefs) {
   return {
     fontFamily: options.fontName,
     src: options.types.reduce<Record<string, string>>((pre, type) => {
       return { ...pre, [type]: `${options.fontName}.${type}` }
     }, {}),
-    codePoints: Object.keys(codePoints).reduce<Record<string, number>>((pre, file) => {
-      const codePoint = codePoints[file]
+    codePoints: Object.keys(fileRefs).reduce<Record<string, number>>((pre, file) => {
+      const codePoint = fileRefs[file]
       return { ...pre, [codePoint.name]: codePoint.codePoint }
     }, {})
   }
 }
 
-export default async function index(files: string[], dest: string, options: Partial<Options> = {}) {
-  const mergedOptions: Options = { ...defaultOptions, ...options }
-  const codePoints = generateCodePoints(files, mergedOptions.startCodePoint)
+export default async function index(root: string, options: Partial<Options> = {}) {
+  const files = glob.sync(path.join(root, '*.svg'))
+  const spec = loadFontSpec(root)
+  const dest = path.join(root, spec.dest)
+  const checkPoint = loadCheckPoint(root)
+  const mergedOptions: Options = { ...defaultOptions, fontName: spec.name }
+  const fileRefs = generateFileRefs(files, mergedOptions.startCodePoint, checkPoint?.fileRefs)
 
-  const generator = buildFontSetGenerator(mergedOptions, codePoints)
+  const generator = buildFontSetGenerator(mergedOptions, fileRefs)
   const fonts = await generator.generate()
   fonts.forEach(font => {
     mkdirp.sync(dest)
     fs.writeFileSync(path.join(dest, `${options.fontName}.${font.type}`), font.data)
   })
 
-  const manifest = buildManifest(mergedOptions, codePoints)
+  const manifest = buildManifest(mergedOptions, fileRefs)
   mkdirp.sync(dest)
   fs.writeFileSync(path.join(dest, 'manifest.json'), JSON.stringify(manifest, null, 2), 'utf8')
+
+  saveCheckPoint(root, { fileRefs })
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,14 +45,14 @@ export default async function index(root: string, options: Partial<Options> = {}
   const spec = loadFontSpec(root)
   const dest = path.join(root, spec.dest)
   const checkPoint = loadCheckPoint(root)
-  const mergedOptions: Options = { ...defaultOptions, fontName: spec.name }
+  const mergedOptions: Options = { ...defaultOptions, ...options, fontName: spec.name }
   const fileRefs = generateFileRefs(files, mergedOptions.startCodePoint, checkPoint?.fileRefs)
 
   const generator = buildFontSetGenerator(mergedOptions, fileRefs)
   const fonts = await generator.generate()
   fonts.forEach(font => {
     mkdirp.sync(dest)
-    fs.writeFileSync(path.join(dest, `${options.fontName}.${font.type}`), font.data)
+    fs.writeFileSync(path.join(dest, `${mergedOptions.fontName}.${font.type}`), font.data)
   })
 
   const manifest = buildManifest(mergedOptions, fileRefs)


### PR DESCRIPTION
To append newly added SVG files, support resuming from previously generated code point map using `fontspec.lock` .