### PR TITLE
v0.2.1: fix fileRef path to use fully relative path

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  presets: [
+    ['@babel/preset-env', { targets: { node: 'current' } }],
+    '@babel/preset-typescript',
+  ],
+}

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,192 @@
+// For a detailed explanation regarding each configuration property, visit:
+// https://jestjs.io/docs/en/configuration.html
+
+module.exports = {
+  // All imported modules in your tests should be mocked automatically
+  // automock: false,
+
+  // Stop running tests after `n` failures
+  // bail: 0,
+
+  // The directory where Jest should store its cached dependency information
+  // cacheDirectory: "/private/var/folders/_9/rctwlr9x6xn474pbttrzwnbw0000gn/T/jest_dx",
+
+  // Automatically clear mock calls and instances between every test
+  clearMocks: true,
+
+  // Indicates whether the coverage information should be collected while executing the test
+  // collectCoverage: false,
+
+  // An array of glob patterns indicating a set of files for which coverage information should be collected
+  // collectCoverageFrom: undefined,
+
+  // The directory where Jest should output its coverage files
+  // coverageDirectory: undefined,
+
+  // An array of regexp pattern strings used to skip coverage collection
+  // coveragePathIgnorePatterns: [
+  //   "/node_modules/"
+  // ],
+
+  // Indicates which provider should be used to instrument code for coverage
+  coverageProvider: "v8",
+
+  // A list of reporter names that Jest uses when writing coverage reports
+  // coverageReporters: [
+  //   "json",
+  //   "text",
+  //   "lcov",
+  //   "clover"
+  // ],
+
+  // An object that configures minimum threshold enforcement for coverage results
+  // coverageThreshold: undefined,
+
+  // A path to a custom dependency extractor
+  // dependencyExtractor: undefined,
+
+  // Make calling deprecated APIs throw helpful error messages
+  // errorOnDeprecated: false,
+
+  // Force coverage collection from ignored files using an array of glob patterns
+  // forceCoverageMatch: [],
+
+  // A path to a module which exports an async function that is triggered once before all test suites
+  // globalSetup: undefined,
+
+  // A path to a module which exports an async function that is triggered once after all test suites
+  // globalTeardown: undefined,
+
+  // A set of global variables that need to be available in all test environments
+  // globals: {},
+
+  // The maximum amount of workers used to run your tests. Can be specified as % or a number. E.g. maxWorkers: 10% will use 10% of your CPU amount + 1 as the maximum worker number. maxWorkers: 2 will use a maximum of 2 workers.
+  // maxWorkers: "50%",
+
+  // An array of directory names to be searched recursively up from the requiring module's location
+  // moduleDirectories: [
+  //   "node_modules"
+  // ],
+
+  // An array of file extensions your modules use
+  // moduleFileExtensions: [
+  //   "js",
+  //   "json",
+  //   "jsx",
+  //   "ts",
+  //   "tsx",
+  //   "node"
+  // ],
+
+  // A map from regular expressions to module names or to arrays of module names that allow to stub out resources with a single module
+  // moduleNameMapper: {},
+
+  // An array of regexp pattern strings, matched against all module paths before considered 'visible' to the module loader
+  // modulePathIgnorePatterns: [],
+
+  // Activates notifications for test results
+  // notify: false,
+
+  // An enum that specifies notification mode. Requires { notify: true }
+  // notifyMode: "failure-change",
+
+  // A preset that is used as a base for Jest's configuration
+  // preset: undefined,
+
+  // Run tests from one or more projects
+  // projects: undefined,
+
+  // Use this configuration option to add custom reporters to Jest
+  // reporters: undefined,
+
+  // Automatically reset mock state between every test
+  // resetMocks: false,
+
+  // Reset the module registry before running each individual test
+  // resetModules: false,
+
+  // A path to a custom resolver
+  // resolver: undefined,
+
+  // Automatically restore mock state between every test
+  // restoreMocks: false,
+
+  // The root directory that Jest should scan for tests and modules within
+  // rootDir: undefined,
+
+  // A list of paths to directories that Jest should use to search for files in
+  // roots: [
+  //   "<rootDir>"
+  // ],
+
+  // Allows you to use a custom runner instead of Jest's default test runner
+  // runner: "jest-runner",
+
+  // The paths to modules that run some code to configure or set up the testing environment before each test
+  // setupFiles: [],
+
+  // A list of paths to modules that run some code to configure or set up the testing framework before each test
+  // setupFilesAfterEnv: [],
+
+  // The number of seconds after which a test is considered as slow and reported as such in the results.
+  // slowTestThreshold: 5,
+
+  // A list of paths to snapshot serializer modules Jest should use for snapshot testing
+  // snapshotSerializers: [],
+
+  // The test environment that will be used for testing
+  testEnvironment: "node",
+
+  // Options that will be passed to the testEnvironment
+  // testEnvironmentOptions: {},
+
+  // Adds a location field to test results
+  // testLocationInResults: false,
+
+  // The glob patterns Jest uses to detect test files
+  // testMatch: [
+  //   "**/__tests__/**/*.[jt]s?(x)",
+  //   "**/?(*.)+(spec|test).[tj]s?(x)"
+  // ],
+
+  // An array of regexp pattern strings that are matched against all test paths, matched tests are skipped
+  // testPathIgnorePatterns: [
+  //   "/node_modules/"
+  // ],
+
+  // The regexp pattern or array of patterns that Jest uses to detect test files
+  // testRegex: [],
+
+  // This option allows the use of a custom results processor
+  // testResultsProcessor: undefined,
+
+  // This option allows use of a custom test runner
+  // testRunner: "jasmine2",
+
+  // This option sets the URL for the jsdom environment. It is reflected in properties such as location.href
+  // testURL: "http://localhost",
+
+  // Setting this value to "fake" allows the use of fake timers for functions such as "setTimeout"
+  // timers: "real",
+
+  // A map from regular expressions to paths to transformers
+  // transform: undefined,
+
+  // An array of regexp pattern strings that are matched against all source file paths, matched files will skip transformation
+  // transformIgnorePatterns: [
+  //   "/node_modules/",
+  //   "\\.pnp\\.[^\\/]+$"
+  // ],
+
+  // An array of regexp pattern strings that are matched against all modules before the module loader will automatically return a mock for them
+  // unmockedModulePathPatterns: undefined,
+
+  // Indicates whether each individual test should be reported during the run
+  // verbose: undefined,
+
+  // An array of regexp patterns that are matched against all source file paths before re-running tests in watch mode
+  // watchPathIgnorePatterns: [],
+
+  // Whether to use watchman for file crawling
+  // watchman: true,
+};

--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
     "build": "npm run clean && npm run compile",
     "clean": "rm -rf ./lib",
     "compile": "tsc",
-    "prepublishOnly": "npm run build",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "jest",
+    "prepublishOnly": "npm run build"
   },
   "keywords": [
     "font",
@@ -43,12 +43,17 @@
     "ttf2woff2": "^3.0.0"
   },
   "devDependencies": {
+    "@babel/core": "^7.12.1",
+    "@babel/preset-env": "^7.12.1",
+    "@babel/preset-typescript": "^7.12.1",
     "@types/commander": "^2.12.2",
     "@types/glob": "^7.1.3",
+    "@types/jest": "^26.0.14",
     "@types/js-yaml": "^3.12.5",
     "@types/mkdirp": "^1.0.1",
     "@types/svg2ttf": "^5.0.0",
     "@types/ttf2woff2": "^2.0.0",
+    "jest": "^26.5.3",
     "ts-node": "^9.0.0",
     "typescript": "^4.0.2"
   }

--- a/src/CheckPoint.ts
+++ b/src/CheckPoint.ts
@@ -12,11 +12,19 @@ interface CheckPoint {
 
 export function loadCheckPoint(root: string): CheckPoint | null {
   const file = path.join(root, filename)
-  if (fs.existsSync(file)) {
-    const content = fs.readFileSync(path.join(root, filename), 'utf8')
-    return JSON.parse(content)
+  if (!fs.existsSync(file)) {
+    return null
   }
-  return null
+
+  const content = fs.readFileSync(path.join(root, filename), 'utf8')
+  const { version, fileRefs } = JSON.parse(content) as CheckPoint
+
+  const migratedFileRefs = Object.keys(fileRefs).reduce<FileRefs>((pre, file) => {
+    const relative = file.startsWith(`${root}/`) ? path.relative(root, file) : file
+      return { ...pre, [relative]: fileRefs[file] }
+  }, {})
+
+  return { version, fileRefs: migratedFileRefs }
 }
 
 const { version } = require('../package.json')

--- a/src/generator/FontGenerator.ts
+++ b/src/generator/FontGenerator.ts
@@ -5,9 +5,10 @@ export type GeneratorType = 'svg' | 'ttf' | FromTTFGeneratorType
 export interface GeneratorOptions {
   fontName: string
   types: GeneratorType[]
+  root: string
 }
 
-export type GeneratedFont = { type: string, data: Buffer}
+export type GeneratedFont = { type: string, data: Buffer }
 
 
 export default abstract class FontGenerator {

--- a/src/generator/SVGGenerator.ts
+++ b/src/generator/SVGGenerator.ts
@@ -1,4 +1,5 @@
 import fs from 'fs'
+import path from 'path'
 import SVGIcons2SVGFontStream from 'svgicons2svgfont'
 import FontGenerator, { GeneratorOptions } from './FontGenerator'
 import { FileRefs } from '../CheckPoint'
@@ -42,7 +43,7 @@ export default class SVGGenerator extends FontGenerator {
         })
 
       Object.keys(this.fileRefs).forEach(file => {
-        const glyph: SVGIconStream = fs.createReadStream(file) as SVGIconStream
+        const glyph: SVGIconStream = fs.createReadStream(path.join(this.options.root, file)) as SVGIconStream
         const { name, codePoint } = this.fileRefs[file]
 
         const ligature = name.split('').map((_, i) => {

--- a/test/CheckPoint.test.ts
+++ b/test/CheckPoint.test.ts
@@ -1,0 +1,23 @@
+import { loadCheckPoint } from '../src/CheckPoint'
+
+describe('loadCheckPoint', () => {
+  it('can parse regular lock file', () => {
+    const checkPoint = loadCheckPoint('test/fixtures/regular')
+    expect(checkPoint?.fileRefs).toStrictEqual({
+      'foo.svg': {
+        name: 'foo',
+        codePoint: 12345
+      }
+    })
+  })
+
+  it('can normalize redundant lock file', () => {
+    const checkPoint = loadCheckPoint('test/fixtures/redundant')
+    expect(checkPoint?.fileRefs).toStrictEqual({
+      'foo.svg': {
+        name: 'foo',
+        codePoint: 12345
+      }
+    })
+  })
+})

--- a/test/fixtures/redundant/fontspec.lock
+++ b/test/fixtures/redundant/fontspec.lock
@@ -1,0 +1,9 @@
+{
+  "fileRefs": {
+    "test/fixtures/redundant/foo.svg": {
+      "name": "foo",
+      "codePoint": 12345
+    }
+  },
+  "version": "0.2.0"
+}

--- a/test/fixtures/regular/fontspec.lock
+++ b/test/fixtures/regular/fontspec.lock
@@ -1,0 +1,9 @@
+{
+  "fileRefs": {
+    "foo.svg": {
+      "name": "foo",
+      "codePoint": 12345
+    }
+  },
+  "version": "0.2.0"
+}


### PR DESCRIPTION
before:

```
root: foo

fontspec.lock:
  fileRefs:
    - foo/bar.svg
```

after:

```
root: foo

fontspec.lock:
  fileRefs:
    - bar.svg
```